### PR TITLE
Allow sending the default sound

### DIFF
--- a/src/herolabs/apns/message.clj
+++ b/src/herolabs/apns/message.clj
@@ -4,11 +4,7 @@
 (defn with-badge [message number] (assoc-in message [:aps :badge ] number))
 
 (defn with-sound [message sound]
-  (cond
-    (= :default sound) (update-in message [:aps ] #(dissoc % :sound ))
-    (= "default" sound) (update-in message [:aps ] #(dissoc % :sound ))
-    :else (assoc-in message [:aps :sound ] sound)
-    )
+  (assoc-in message [:aps :sound ] (name sound))
   )
 
 (defn with-standard-alert [message body]
@@ -45,3 +41,4 @@
     (assoc-in message [:aps :alert :body ] body)
     message)
   )
+

--- a/test/herolabs_test/apns/message.clj
+++ b/test/herolabs_test/apns/message.clj
@@ -7,9 +7,9 @@
 
 (facts "about message assembly"
   (with-badge {} 1) => (just {:aps {:badge 1}})
-  (with-sound {} :default) => (just {:aps nil})
-  (with-sound {} "default") => (just {:aps nil})
-  (with-sound {} :chimes) => (just {:aps {:sound :chimes}})
+  (with-sound {} :default) => (just {:aps {:sound "default"}})
+  (with-sound {} "default") => (just {:aps {:sound "default"}})
+  (with-sound {} :chimes) => (just {:aps {:sound "chimes"}})
   (with-standard-alert {} "Hello world") => (just {:aps {:alert "Hello world"}})
   (with-action-loc-key {} "TEST") => (just {:aps {:alert {:action-loc-key "TEST"}}})
   (with-loc-key {} "TEST") => (just {:aps {:alert {:loc-key "TEST"}}})


### PR DESCRIPTION
I was having trouble figuring out why I could not get the default sound to play when pushing alerts using herolabs-apns, and found that the library is currently stripping out any attempts (via `with-sound`) to send a value of "default."

There is a difference between having a `sound` value of `default` and having no `sound` value at all. The latter leads to a silent alert, while the former is Apple's preferred way of requesting the standard notification sound. Per the Apple Push Notification Service Programming Guide, Table 2-1 on Page 20:

> The Name of a sound file in the application bundle. The sound in this file is played as an alert. If the sound file doesn’t exist or `default` is specified as the value, the default alert sound is played. The audio must be in…

Since this is a file name, I thought it would be best to convert any keywords to strings, although you may do that elsewhere in the library anyway.
