### PR TITLE
threads are mutable. .setPriority and .setDaemon return nil. Fixing so t...

### DIFF
--- a/src/herolabs/apns/push.clj
+++ b/src/herolabs/apns/push.clj
@@ -28,9 +28,9 @@
                       sm (System/getSecurityManager)
                       group (if sm (.getThreadGroup sm) (.getThreadGroup (Thread/currentThread)))]
                   (reify ThreadFactory
-                    (newThread [_ r] (let [t (Thread. group r (str "apns-push-pool-" (swap! number inc)) 0)
-                                           t (if (.isDaemon t) (.setDaemon t false) t)
-                                           t (if (not= Thread/NORM_PRIORITY (.getPriority t)) (.setPriority t Thread/NORM_PRIORITY) t)]
+                    (newThread [_ r] (let [t (Thread. group r (str "apns-push-pool-" (swap! number inc)) 0)]
+                                       (when (.isDaemon t) (.setDaemon t false))
+                                       (when (not= Thread/NORM_PRIORITY (.getPriority t)) (.setPriority t Thread/NORM_PRIORITY))
                                        t)))))))))
 
 (def ^:private timer* (ref nil))


### PR DESCRIPTION
Hi
Just fixed a bug, where threads were dying because java thread is mutable and .setPriority and .setDaemon were returning nil.

Thanks
Anand
