### PR TITLE
merge payload into message to preserve message metadata

### DIFF
--- a/src/herolabs/apns/message.clj
+++ b/src/herolabs/apns/message.clj
@@ -54,7 +54,7 @@
 (defn with-payload
   "Adds additional payload to the message (everything except the :aps key)."
   [message payload] (if-not (empty? payload)
-                      (merge (dissoc payload :aps ) message)
+                      (merge message (dissoc payload :aps))
                       message))
 
 (defn with-alert-body

--- a/test/herolabs_test/apns/message.clj
+++ b/test/herolabs_test/apns/message.clj
@@ -16,5 +16,6 @@
   (with-loc-args {} "foo") => (just {:aps (just {:alert (just {:loc-args (just ["foo"])})})})
   (with-loc-args {} ["foo" "bar"]) => (just {:aps (just {:alert (just {:loc-args (just ["foo" "bar"])})})})
   (with-alert-body {} "TEST") => (just {:aps {:alert {:body "TEST"}}})
+  (meta (herolabs.apns.message/with-payload (with-meta {:foo :bar} {:a :b}) {:pay :load})) => {:a :b}
   )
 


### PR DESCRIPTION
If message/to came before message/with-payload, :device-token in the message's metadata was getting killed by the merge.
