### PR TITLE
Docstrings come before args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ pom.xml.asc
 *.ipr
 *.iws
 scrapbook.clj
+/.nrepl-port

--- a/src/herolabs/apns/push.clj
+++ b/src/herolabs/apns/push.clj
@@ -136,8 +136,9 @@
                   (:no-super (meta h)))
         (proxy-super exceptionCaught ctx cause)))))
 
-(defn- create-channel-initializer [ssl-engine protocoll-handler sent-queue id-gen time-out expires priority]
+(defn- create-channel-initializer
   "Creates a pipeline factory"
+  [ssl-engine protocoll-handler sent-queue id-gen time-out expires priority]
   (proxy [ChannelInitializer] []
     (initChannel [^SocketChannel channel]
       (let [pipeline (.pipeline channel)]
@@ -150,8 +151,9 @@
 (defn- default-exception-handler [cause] (info cause "An exception occured while sending push notification to the server."))
 
 
-(defn- connect [^InetSocketAddress address ^SSLContext ssl-context handlers event-loop id-generator time-out expires priority]
+(defn- connect
   "Creates a Netty Channel to connect to the server."
+  [^InetSocketAddress address ^SSLContext ssl-context handlers event-loop id-generator time-out expires priority]
   (let [ssl-engine (ssl-engine ssl-context :use-client-mode true)
         sent-queue (atom (sorted-set-by queue-entry-comparator))
         bootstrap (-> (Bootstrap.)

--- a/src/herolabs/apns/ssl.clj
+++ b/src/herolabs/apns/ssl.clj
@@ -55,23 +55,26 @@
       (.setKeyEntry "apple-push-service" key (char-array nil) certs))))
 
 
-(defn ssl-engine [^SSLContext context & {:keys [use-client-mode] :or {use-client-mode true}}]
+(defn ssl-engine
   "Creates an SSL engine"
+  [^SSLContext context & {:keys [use-client-mode] :or {use-client-mode true}}]
   (let [^SSLEngine engine (.createSSLEngine context)]
     (if use-client-mode
       (doto engine (.setUseClientMode use-client-mode))
       engine)))
 
-(defn ssl-engine-factory [^SSLContext context & {:keys [use-client-mode] :or {use-client-mode true}}]
+(defn ssl-engine-factory
   "Creates an SSL engine"
+  [^SSLContext context & {:keys [use-client-mode] :or {use-client-mode true}}]
   (fn [] (let [engine (.createSSLEngine context)]
           (if use-client-mode
             (doto engine (.setUseClientMode use-client-mode))
             engine))))
 
 
-(defn naive-trust-managers [& {:keys [trace] :or [trace false]}]
+(defn naive-trust-managers
   "Creates a very naive trust manager that will accept all certificates."
+  [& {:keys [trace] :or [trace false]}]
   (into-array (list (proxy [javax.net.ssl.X509TrustManager] []
                       (getAcceptedIssuers [] (make-array X509Certificate 0))
                       (checkClientTrusted [ chain auth-type]


### PR DESCRIPTION
`defn` places docstrings before the arguments vector, not after, which
causes the documentation to not be available to cider (or whatever IDE
people might be using other than cider+emacs)
